### PR TITLE
feat: enhance CLI migration workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,14 @@ uni-orm detect
 # Same-type migration (MySQL to PostgreSQL)
 uni-orm migrate --from mysql --to postgresql
 
+# Shorthand form
+uni-orm mysql migrate postgresql
+
 # Cross-type migration (SQL to NoSQL)
 uni-orm migrate --from postgresql --to mongodb
+
+# Apply saved cross-database change
+uni-orm pull dbchange <change-id>
 
 # Data-only migration
 uni-orm migrate --from mysql --to postgresql --type data
@@ -151,6 +157,9 @@ Migrations between similar database types (SQL to SQL, NoSQL to NoSQL) are handl
 # SQL to SQL migration
 uni-orm migrate --from mysql --to postgresql
 
+# Shorthand
+uni-orm mysql migrate postgresql
+
 # NoSQL to NoSQL migration
 uni-orm migrate --from mongodb --to couchdb
 ```
@@ -162,6 +171,9 @@ For migrations between different database types (SQL to NoSQL or vice versa), Un
 ```bash
 # This will launch the dashboard for visual migration
 uni-orm migrate --from postgresql --to mongodb
+
+# After saving in dashboard
+uni-orm pull dbchange <change-id>
 ```
 
 The dashboard provides:

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -16,6 +16,20 @@ console.log(
 );
 console.log(chalk.yellow('Universal ORM for all programming languages\n'));
 
+// Support syntax: "uni-orm <from> migrate <to>"
+const cliArgs = process.argv.slice(2);
+if (
+  cliArgs.length === 3 &&
+  !cliArgs[0].startsWith('-') &&
+  cliArgs[1] === 'migrate'
+) {
+  const migrationManager = new MigrationManager();
+  migrationManager
+    .migrate({ from: cliArgs[0], to: cliArgs[2] })
+    .catch(err => console.error(chalk.red(err.message)));
+  return;
+}
+
 program
   .name('uni-orm')
   .description('Universal ORM CLI')
@@ -77,6 +91,16 @@ program
   .action(async (options) => {
     const uniorm = new UniORM();
     await uniorm.sync(options);
+  });
+
+// Pull commands
+const pull = program.command('pull').description('Apply saved changes');
+pull
+  .command('dbchange <id>')
+  .description('Apply a cross-database change generated from the dashboard')
+  .action(async (id) => {
+    const migrationManager = new MigrationManager();
+    await migrationManager.pullDbChange(id);
   });
 
 program.parse();


### PR DESCRIPTION
## Summary
- support shorthand syntax `uni-orm <from> migrate <to>`
- add `pull dbchange` command for applying cross-database changes
- prompt before cross-type migrations and generate change IDs
- document new CLI workflow in README
