### PR TITLE
feat: add dashboard server and mapping UI

### DIFF
--- a/dashboard/public/app.js
+++ b/dashboard/public/app.js
@@ -1,0 +1,122 @@
+const tablesEl = document.getElementById('tables');
+const collectionsEl = document.getElementById('collections');
+const outputEl = document.getElementById('output');
+
+// Sample schema data. In real usage this would come from the server.
+const schema = [
+  { name: 'users', columns: ['id', 'name', 'email'] },
+  { name: 'posts', columns: ['id', 'title', 'body', 'user_id'] }
+];
+
+const mapping = {};
+
+function renderTables() {
+  schema.forEach(table => {
+    const wrapper = document.createElement('div');
+    const tableDiv = document.createElement('div');
+    tableDiv.textContent = table.name;
+    tableDiv.className = 'draggable';
+    tableDiv.draggable = true;
+    tableDiv.addEventListener('dragstart', e => {
+      e.dataTransfer.setData('type', 'table');
+      e.dataTransfer.setData('table', table.name);
+    });
+    wrapper.appendChild(tableDiv);
+
+    table.columns.forEach(col => {
+      const colDiv = document.createElement('div');
+      colDiv.textContent = `- ${col}`;
+      colDiv.className = 'draggable';
+      colDiv.style.marginLeft = '10px';
+      colDiv.draggable = true;
+      colDiv.addEventListener('dragstart', e => {
+        e.dataTransfer.setData('type', 'column');
+        e.dataTransfer.setData('table', table.name);
+        e.dataTransfer.setData('column', col);
+      });
+      wrapper.appendChild(colDiv);
+    });
+
+    tablesEl.appendChild(wrapper);
+  });
+}
+
+collectionsEl.addEventListener('dragover', e => {
+  e.preventDefault();
+});
+
+collectionsEl.addEventListener('drop', e => {
+  e.preventDefault();
+  const type = e.dataTransfer.getData('type');
+  if (type === 'table') {
+    const tableName = e.dataTransfer.getData('table');
+    if (mapping[tableName]) return; // already mapped
+    const collectionName = prompt('Collection name for ' + tableName, tableName);
+    if (!collectionName) return;
+    const colEl = document.createElement('div');
+    colEl.className = 'collection';
+    colEl.dataset.table = tableName;
+    colEl.innerHTML = `<h4>${collectionName}</h4><div class="fields dropzone"></div>`;
+    collectionsEl.appendChild(colEl);
+    mapping[tableName] = { collection: collectionName, fields: {} };
+
+    const fieldsDrop = colEl.querySelector('.fields');
+    fieldsDrop.addEventListener('dragover', evt => evt.preventDefault());
+    fieldsDrop.addEventListener('drop', evt => {
+      evt.preventDefault();
+      const t = evt.dataTransfer.getData('type');
+      if (t !== 'column') return;
+      const srcTable = evt.dataTransfer.getData('table');
+      if (srcTable !== tableName) return; // ensure from same table
+      const columnName = evt.dataTransfer.getData('column');
+      const fieldName = prompt('Field name for ' + columnName, columnName);
+      if (!fieldName) return;
+      mapping[tableName].fields[columnName] = fieldName;
+      const fieldDiv = document.createElement('div');
+      fieldDiv.textContent = columnName + ' → ' + fieldName;
+      fieldsDrop.appendChild(fieldDiv);
+    });
+  }
+});
+
+renderTables();
+
+function collectOptions() {
+  return {
+    relationStrategy: document.getElementById('relationStrategy').value,
+    idStrategy: document.getElementById('idStrategy').value,
+    decimalMode: document.getElementById('decimalMode').value
+  };
+}
+
+document.getElementById('previewBtn').addEventListener('click', async () => {
+  try {
+    const res = await fetch('/api/mapping/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mapping, options: collectOptions() })
+    });
+    const data = await res.json();
+    outputEl.textContent = JSON.stringify(data, null, 2);
+  } catch (err) {
+    outputEl.textContent = 'Error: ' + err.message;
+  }
+});
+
+document.getElementById('saveBtn').addEventListener('click', async () => {
+  try {
+    const res = await fetch('/api/changesets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mapping, options: collectOptions() })
+    });
+    const data = await res.json();
+    if (data.token) {
+      outputEl.textContent = `Token: ${data.token}\nCommand: uniorm pull dbchange ${data.token}`;
+    } else {
+      outputEl.textContent = JSON.stringify(data, null, 2);
+    }
+  } catch (err) {
+    outputEl.textContent = 'Error: ' + err.message;
+  }
+});

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>UniORM Dashboard</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin:0; padding:1rem; }
+    .flex { display: flex; gap: 1rem; }
+    .panel { flex: 1; border: 1px solid #ccc; padding: 1rem; min-height: 200px; }
+    .draggable { padding: 4px; border: 1px solid #999; margin-bottom: 4px; background: #f7f7f7; cursor: move; }
+    .dropzone { min-height: 50px; border: 1px dashed #aaa; padding: 4px; }
+    #output { white-space: pre-wrap; margin-top: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>UniORM Mapping</h1>
+  <div class="flex">
+    <div class="panel">
+      <h3>Tables</h3>
+      <div id="tables"></div>
+    </div>
+    <div class="panel">
+      <h3>Collections</h3>
+      <div id="collections" class="dropzone"></div>
+    </div>
+  </div>
+
+  <div class="panel" style="margin-top:1rem;">
+    <h3>Options</h3>
+    <label>Per-relation strategy:
+      <select id="relationStrategy">
+        <option value="embed">embed</option>
+        <option value="reference">reference</option>
+      </select>
+    </label>
+    <br/>
+    <label>ID strategy:
+      <select id="idStrategy">
+        <option value="uuid">uuid</option>
+        <option value="objectId">objectId</option>
+      </select>
+    </label>
+    <br/>
+    <label>Decimal mode:
+      <select id="decimalMode">
+        <option value="string">string</option>
+        <option value="decimal128">decimal128</option>
+      </select>
+    </label>
+    <br/>
+    <button id="previewBtn">Preview Transform</button>
+    <button id="saveBtn">Save & Generate Token</button>
+  </div>
+
+  <pre id="output"></pre>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const path = require('path');
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Serve static files from the dashboard/public directory
+const publicDir = path.join(__dirname, 'public');
+app.use(express.static(publicDir));
+
+// Proxy API calls to the engine running on localhost:6499
+app.use('/api', createProxyMiddleware({
+  target: 'http://localhost:6499',
+  changeOrigin: true,
+  pathRewrite: { '^/api': '' }
+}));
+
+app.listen(PORT, () => {
+  console.log(`Dashboard server listening on http://localhost:${PORT}`);
+});
+
+module.exports = app;

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "fs-extra": "^11.1.1",
+        "http-proxy-middleware": "^3.0.5",
         "inquirer": "^9.2.12",
         "mongodb": "^5.9.2",
         "node-fetch": "^3.3.2",
@@ -2513,6 +2514,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/http-proxy": {
+      "version": "1.17.16",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.16.tgz",
+      "integrity": "sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -3048,7 +3058,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -3906,6 +3915,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -4117,7 +4132,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -4156,6 +4170,26 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/formdata-polyfill": {
@@ -4477,6 +4511,60 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-proxy-middleware": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
+      "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.15",
+        "debug": "^4.3.6",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.3",
+        "is-plain-object": "^5.0.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/http-proxy-middleware/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-proxy-middleware/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
@@ -4935,7 +5023,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4964,7 +5051,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -4989,10 +5075,18 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-stream": {
@@ -5953,7 +6047,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -6685,7 +6778,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -7245,6 +7337,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -8063,7 +8161,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "commander": "^11.1.0",
     "cors": "^2.8.5",
     "express": "^4.18.2",
+    "http-proxy-middleware": "^3.0.5",
     "fs-extra": "^11.1.1",
     "inquirer": "^9.2.12",
     "mongodb": "^5.9.2",


### PR DESCRIPTION
## Summary
- add Express dashboard server with API proxy
- build basic mapping interface for tables and columns
- integrate save and preview actions returning CLI token

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6896550956508323b9cd19c212c7c53c