### PR TITLE
feat: add schema diff with migration history

### DIFF
--- a/__tests__/db_push_pull.test.js
+++ b/__tests__/db_push_pull.test.js
@@ -1,0 +1,59 @@
+const fs = require('fs-extra');
+const path = require('path');
+const os = require('os');
+const YAML = require('yaml');
+
+const { push, pull } = require('../engine/src/db');
+
+describe('db push/pull', () => {
+  let cwd;
+  let tmp;
+
+  beforeEach(async () => {
+    cwd = process.cwd();
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'uni-orm-'));
+    process.chdir(tmp);
+  });
+
+  afterEach(async () => {
+    process.chdir(cwd);
+    await fs.remove(tmp);
+  });
+
+  test('push updates and pull reflects schema', async () => {
+    const schema1 = YAML.stringify({
+      tables: [{ name: 'users', columns: [{ name: 'id' }, { name: 'name' }] }]
+    });
+    await push({ provider: 'sqlite', url: 'file:mem', schemaYaml: schema1 });
+    let result = await pull({ provider: 'sqlite', url: 'file:mem' });
+    expect(result.ir.tables[0].name).toBe('users');
+
+    const schema2 = YAML.stringify({
+      tables: [
+        { name: 'users', columns: [{ name: 'id' }, { name: 'name' }, { name: 'email' }] }
+      ]
+    });
+    await push({ provider: 'sqlite', url: 'file:mem', schemaYaml: schema2 });
+    result = await pull({ provider: 'sqlite', url: 'file:mem' });
+    const columnNames = result.ir.tables[0].columns.map(c => c.name);
+    expect(columnNames).toContain('email');
+
+    const schema3 = YAML.stringify({
+      tables: [{ name: 'users', columns: [{ name: 'id' }] }]
+    });
+    await expect(
+      push({ provider: 'sqlite', url: 'file:mem', schemaYaml: schema3 })
+    ).rejects.toThrow();
+    await push({ provider: 'sqlite', url: 'file:mem', schemaYaml: schema3, force: true });
+  });
+
+  test('migration history files are created', async () => {
+    const schema1 = YAML.stringify({ tables: [] });
+    await push({ provider: 'sqlite', url: 'file', schemaYaml: schema1 });
+    const schema2 = YAML.stringify({ tables: [{ name: 't', columns: [] }] });
+    await push({ provider: 'sqlite', url: 'file', schemaYaml: schema2 });
+    const migrationsDir = path.join(process.cwd(), '.uni-orm', 'migrations');
+    const files = await fs.readdir(migrationsDir);
+    expect(files.length).toBeGreaterThan(0);
+  });
+});

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -90,7 +90,8 @@ db
 db
   .command('push')
   .description('Push uniorm.schema.yaml to database')
-  .action(async () => {
+  .option('--force', 'Allow destructive changes (drops)')
+  .action(async (opts) => {
     const configPath = path.join(process.cwd(), '.uni-orm', 'config.json');
     const { provider, url } = JSON.parse(fs.readFileSync(configPath, 'utf8'));
     const schemaPath = path.join(process.cwd(), 'uniorm.schema.yaml');
@@ -98,7 +99,7 @@ db
     const res = await fetch('http://localhost:6499/db/push', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ provider, url, schemaYaml })
+      body: JSON.stringify({ provider, url, schemaYaml, force: opts.force })
     });
     const data = await res.json();
     console.log(data);

--- a/engine/src/db.js
+++ b/engine/src/db.js
@@ -1,9 +1,114 @@
+const fs = require('fs-extra');
+const path = require('path');
+const YAML = require('yaml');
+
+/**
+ * Load the current schema representation from the pseudo database.
+ * The schema is stored in `.uni-orm/db.schema.yaml` relative to the
+ * project root (process.cwd()).
+ */
 async function pull({ provider, url }) {
-  return { provider, url, ir: {} };
+  const configDir = path.join(process.cwd(), '.uni-orm');
+  const schemaPath = path.join(configDir, 'db.schema.yaml');
+
+  let ir = {};
+  if (await fs.pathExists(schemaPath)) {
+    const text = await fs.readFile(schemaPath, 'utf8');
+    ir = YAML.parse(text) || {};
+  }
+
+  return { provider, url, ir };
 }
 
-async function push({ provider, url, schemaYaml }) {
-  return { provider, url, applied: true };
+/**
+ * Push a new schema representation to the pseudo database. The
+ * function performs a very small diff between the existing schema and
+ * the new one and records the operations in
+ * `.uni-orm/migrations/<timestamp>.json`.
+ *
+ * Destructive operations (drops of tables or columns) are blocked by
+ * default and require `force: true` to proceed.
+ */
+async function push({ provider, url, schemaYaml, force = false }) {
+  const configDir = path.join(process.cwd(), '.uni-orm');
+  const schemaPath = path.join(configDir, 'db.schema.yaml');
+  await fs.ensureDir(configDir);
+
+  const newSchema = YAML.parse(schemaYaml || '') || { tables: [] };
+  let oldSchema = { tables: [] };
+  if (await fs.pathExists(schemaPath)) {
+    const oldText = await fs.readFile(schemaPath, 'utf8');
+    oldSchema = YAML.parse(oldText) || { tables: [] };
+  }
+
+  const oldTables = oldSchema.tables || [];
+  const newTables = newSchema.tables || [];
+
+  const addedTables = [];
+  const removedTables = [];
+  const changedTables = [];
+
+  // Determine table-level changes
+  const tableMapOld = new Map(oldTables.map((t) => [t.name, t]));
+  const tableMapNew = new Map(newTables.map((t) => [t.name, t]));
+
+  for (const [name, table] of tableMapOld.entries()) {
+    if (!tableMapNew.has(name)) {
+      removedTables.push(name);
+    }
+  }
+
+  for (const [name, table] of tableMapNew.entries()) {
+    if (!tableMapOld.has(name)) {
+      addedTables.push(name);
+    } else {
+      const oldTable = tableMapOld.get(name);
+      const oldCols = oldTable.columns || [];
+      const newCols = table.columns || [];
+
+      const addedColumns = [];
+      const removedColumns = [];
+
+      const colMapOld = new Map(oldCols.map((c) => [c.name, c]));
+      const colMapNew = new Map(newCols.map((c) => [c.name, c]));
+
+      for (const [cname] of colMapOld.entries()) {
+        if (!colMapNew.has(cname)) {
+          removedColumns.push(cname);
+        }
+      }
+
+      for (const [cname] of colMapNew.entries()) {
+        if (!colMapOld.has(cname)) {
+          addedColumns.push(cname);
+        }
+      }
+
+      if (addedColumns.length || removedColumns.length) {
+        changedTables.push({ name, addedColumns, removedColumns });
+      }
+    }
+  }
+
+  // Guard against destructive changes
+  const destructiveTables = removedTables.length > 0;
+  const destructiveColumns = changedTables.some((t) => t.removedColumns.length > 0);
+  if ((destructiveTables || destructiveColumns) && !force) {
+    throw new Error('Destructive changes detected. Use --force to apply.');
+  }
+
+  // Persist the new schema
+  await fs.writeFile(schemaPath, YAML.stringify(newSchema));
+
+  // Write migration history
+  const migrationsDir = path.join(configDir, 'migrations');
+  await fs.ensureDir(migrationsDir);
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const migration = { addedTables, removedTables, changedTables };
+  const migrationPath = path.join(migrationsDir, `${timestamp}.json`);
+  await fs.writeFile(migrationPath, JSON.stringify(migration, null, 2));
+
+  return { provider, url, applied: true, migration };
 }
 
 module.exports = { pull, push };


### PR DESCRIPTION
## Summary
- add basic schema diffing and migration history for db push
- support force flag in CLI to allow destructive changes
- cover db push/pull and migrations with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68965af6e88883238001e37e853364bf