### PR TITLE
feat: add sample migration planner and applier

### DIFF
--- a/__tests__/migration.sample.test.js
+++ b/__tests__/migration.sample.test.js
@@ -1,0 +1,45 @@
+const fs = require('fs-extra');
+const path = require('path');
+const os = require('os');
+const { spawn } = require('child_process');
+
+jest.setTimeout(30000);
+
+describe('mysql to postgres migration sample', () => {
+  let tmpDir;
+  let server;
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'uniorm-sample-'));
+    const sampleSrc = path.join(__dirname, '..', 'engine', 'sample-data');
+    await fs.copy(sampleSrc, tmpDir);
+    server = spawn('node', ['engine/server.js'], {
+      cwd: path.join(__dirname, '..'),
+      env: { ...process.env, UNIORM_SAMPLE_DIR: tmpDir },
+      stdio: 'ignore'
+    });
+    await new Promise((res) => setTimeout(res, 500));
+  });
+
+  afterAll(async () => {
+    if (server) server.kill();
+    await fs.remove(tmpDir);
+  });
+
+  test('cli migrate copies schema and data', async () => {
+    await new Promise((resolve, reject) => {
+      const cli = spawn('node', ['bin/cli.js', 'mysql', 'migrate', 'postgres'], {
+        cwd: path.join(__dirname, '..'),
+        env: { ...process.env, UNIORM_SAMPLE_DIR: tmpDir }
+      });
+      cli.on('exit', (code) => {
+        if (code === 0) resolve();
+        else reject(new Error(`exit code ${code}`));
+      });
+    });
+    const mysql = await fs.readJson(path.join(tmpDir, 'mysql.json'));
+    const postgres = await fs.readJson(path.join(tmpDir, 'postgres.json'));
+    expect(postgres.schema.tables.length).toBe(mysql.schema.tables.length);
+    expect(postgres.data.users).toEqual(mysql.data.users);
+  });
+});

--- a/engine/sample-data/mysql.json
+++ b/engine/sample-data/mysql.json
@@ -1,0 +1,21 @@
+{
+  "schema": {
+    "tables": [
+      {
+        "name": "users",
+        "columns": [
+          { "name": "id", "type": "INTEGER", "pk": true, "nullable": false },
+          { "name": "name", "type": "TEXT", "pk": false, "nullable": false }
+        ],
+        "indexes": [],
+        "fks": []
+      }
+    ]
+  },
+  "data": {
+    "users": [
+      { "id": 1, "name": "Alice" },
+      { "id": 2, "name": "Bob" }
+    ]
+  }
+}

--- a/engine/sample-data/postgres.json
+++ b/engine/sample-data/postgres.json
@@ -1,0 +1,6 @@
+{
+  "schema": {
+    "tables": []
+  },
+  "data": {}
+}

--- a/engine/src/migrations.js
+++ b/engine/src/migrations.js
@@ -1,8 +1,118 @@
-async function plan({ from, to, options }) {
-  return { ops: [] };
+const fs = require('fs-extra');
+const path = require('path');
+
+function sampleDir() {
+  return process.env.UNIORM_SAMPLE_DIR || path.join(__dirname, '..', 'sample-data');
 }
 
-async function applyPlan({ plan }) {
+async function loadSample(provider) {
+  const file = path.join(sampleDir(), `${provider}.json`);
+  return fs.readJson(file);
+}
+
+async function saveSample(provider, data) {
+  const file = path.join(sampleDir(), `${provider}.json`);
+  await fs.writeJson(file, data, { spaces: 2 });
+}
+
+async function plan({ from, to }) {
+  const fromDb = await loadSample(from.provider);
+  const toDb = await loadSample(to.provider);
+
+  const ops = [];
+  const tablesToCopy = [];
+  const toTableMap = new Map((toDb.schema.tables || []).map((t) => [t.name, t]));
+
+  for (const table of fromDb.schema.tables || []) {
+    tablesToCopy.push(table.name);
+    const target = toTableMap.get(table.name);
+    if (!target) {
+      ops.push({ type: 'create_table', table: table.name });
+      for (const col of table.columns || []) {
+        ops.push({ type: 'add_column', table: table.name, column: col });
+      }
+      for (const idx of table.indexes || []) {
+        ops.push({ type: 'create_index', table: table.name, index: idx });
+      }
+      for (const fk of table.fks || []) {
+        ops.push({ type: 'add_fk', table: table.name, fk });
+      }
+    } else {
+      const targetCols = new Set((target.columns || []).map((c) => c.name));
+      for (const col of table.columns || []) {
+        if (!targetCols.has(col.name)) {
+          ops.push({ type: 'add_column', table: table.name, column: col });
+        }
+      }
+      const targetIdxs = new Set((target.indexes || []).map((i) => i.name));
+      for (const idx of table.indexes || []) {
+        if (!targetIdxs.has(idx.name)) {
+          ops.push({ type: 'create_index', table: table.name, index: idx });
+        }
+      }
+      const targetFks = new Set((target.fks || []).map((f) => f.name));
+      for (const fk of table.fks || []) {
+        if (!targetFks.has(fk.name)) {
+          ops.push({ type: 'add_fk', table: table.name, fk });
+        }
+      }
+    }
+  }
+
+  return { ops, tables: tablesToCopy, from: from.provider, to: to.provider };
+}
+
+async function applyPlan({ plan, batchSize = 10000 }) {
+  const fromDb = await loadSample(plan.from);
+  const toDb = await loadSample(plan.to);
+
+  const newSchema = JSON.parse(JSON.stringify(toDb.schema));
+  const newData = JSON.parse(JSON.stringify(toDb.data));
+
+  for (const op of plan.ops) {
+    switch (op.type) {
+      case 'create_table': {
+        newSchema.tables.push({ name: op.table, columns: [], indexes: [], fks: [] });
+        break;
+      }
+      case 'add_column': {
+        const tbl = newSchema.tables.find((t) => t.name === op.table);
+        if (tbl) {
+          tbl.columns = tbl.columns || [];
+          tbl.columns.push(op.column);
+        }
+        break;
+      }
+      case 'create_index': {
+        const tbl = newSchema.tables.find((t) => t.name === op.table);
+        if (tbl) {
+          tbl.indexes = tbl.indexes || [];
+          tbl.indexes.push(op.index);
+        }
+        break;
+      }
+      case 'add_fk': {
+        const tbl = newSchema.tables.find((t) => t.name === op.table);
+        if (tbl) {
+          tbl.fks = tbl.fks || [];
+          tbl.fks.push(op.fk);
+        }
+        break;
+      }
+    }
+  }
+
+  const fromData = fromDb.data || {};
+  for (const table of plan.tables || []) {
+    const rows = fromData[table] || [];
+    for (let i = 0; i < rows.length; i += batchSize) {
+      const batch = rows.slice(i, i + batchSize);
+      newData[table] = newData[table] || [];
+      newData[table].push(...batch);
+    }
+  }
+
+  await saveSample(plan.to, { schema: newSchema, data: newData });
   return { applied: true };
 }
 


### PR DESCRIPTION
## Summary
- implement planner that generates ordered create-table operations using sample schemas
- add applier that applies ops and copies table data in 10k-row batches
- include sample MySQL/Postgres data and integration test validating CLI migration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68965c97cdb08323a80b8402ae1ecd7a