### PR TITLE
Add e2e examples and test script

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+services:
+  mysql:
+    image: mysql:8
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: test
+    ports:
+      - "3306:3306"
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: test
+    ports:
+      - "5432:5432"
+  mongodb:
+    image: mongo:6
+    ports:
+      - "27017:27017"

--- a/examples/node-ts/example.ts
+++ b/examples/node-ts/example.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@uniorm/client';
+const { createClient } = require('../../generated/ts');
 
 async function main() {
   const client = createClient({ baseUrl: 'http://localhost:6499' });
@@ -14,4 +14,7 @@ async function main() {
   console.log('Deleted user');
 }
 
-main();
+main().catch((err: any) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/py/example.py
+++ b/examples/py/example.py
@@ -1,5 +1,5 @@
 import os, sys
-sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', 'generated', 'py'))
 from uniorm import create_client
 
 client = create_client('http://localhost:6499')

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "build": "npm run build:cli && npm run build:dashboard",
     "build:cli": "pkg bin/cli.js --out-path dist/",
     "build:dashboard": "cd src/dashboard && npm run build",
-    "build:bin": "pkg ./bin/cli.js --targets node18-linux-x64,node18-macos-x64,node18-win-x64 --output dist/uniorm"
+    "build:bin": "pkg ./bin/cli.js --targets node18-linux-x64,node18-macos-x64,node18-win-x64 --output dist/uniorm",
+    "test:e2e": "node scripts/e2e.js"
   },
   "keywords": [
     "orm",

--- a/scripts/e2e.js
+++ b/scripts/e2e.js
@@ -1,0 +1,76 @@
+const { spawn } = require('child_process');
+const fs = require('fs-extra');
+const path = require('path');
+
+function run(cmd, args, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const p = spawn(cmd, args, { stdio: 'inherit', ...opts });
+    p.on('error', reject);
+    p.on('exit', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${cmd} exited with code ${code}`));
+    });
+  });
+}
+
+async function runDocker(cmdArgs) {
+  try {
+    await run('docker', ['compose', '-f', 'docker-compose.e2e.yml', ...cmdArgs]);
+  } catch (err) {
+    console.warn('docker compose not available, skipping:', err.message);
+  }
+}
+
+async function main() {
+  const root = path.join(__dirname, '..');
+  process.chdir(root);
+
+  await fs.remove(path.join(root, '.uni-orm'));
+  await fs.remove(path.join(root, 'generated'));
+
+  await runDocker(['up', '-d']);
+
+  const server = spawn('node', ['engine/server.js'], { cwd: root, stdio: 'inherit' });
+  await new Promise((r) => setTimeout(r, 1000));
+
+  try {
+    await fetch('http://localhost:6499/project/init', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ language: 'ts', provider: 'mysql', url: 'mysql://root:password@localhost:3306/test' })
+    });
+
+    await run('node', ['bin/cli.js', 'db', 'push', '--force'], { cwd: root });
+    await run('node', ['bin/cli.js', 'generate'], { cwd: root });
+
+    await run('npx', ['ts-node', '--compiler-options', '{"module":"CommonJS"}', '--transpile-only', 'examples/node-ts/example.ts'], { cwd: root });
+    await run('python', ['examples/py/example.py'], { cwd: root });
+
+    await run('node', ['bin/cli.js', 'postgres', 'migrate', 'mysql'], { cwd: root });
+
+    const planRes = await fetch('http://localhost:6499/migrations/plan', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ from: { provider: 'mysql' }, to: { provider: 'mongodb' } })
+    });
+    const plan = await planRes.json();
+    const tokenRes = await fetch('http://localhost:6499/changesets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ plan })
+    });
+    const { token } = await tokenRes.json();
+
+    await run('node', ['bin/cli.js', 'pull', 'dbchange', token], { cwd: root });
+
+    console.log('E2E flow completed');
+  } finally {
+    server.kill();
+    await runDocker(['down']);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add node-ts and python CRUD examples using generated SDKs
- introduce docker-compose and e2e runner covering init, push, generate, CRUD, migration and changesets
- expose `npm run test:e2e` for end-to-end verification

## Testing
- `npm test`
- `npm run test:e2e` *(fails: docker compose not available, skipping: spawn docker ENOENT)*