### PR TITLE
ci: checkout before downloading release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,12 @@ permissions:
   contents: write
 
 jobs:
-  create-release:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
## Summary
- ensure release workflow checks out repository before retrieving artifacts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689f0e05c0b4832398a27c95d72f2940