### PR TITLE
ci: add os/node matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         node: [18]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node: [18]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm ci
+      - run: npm test

--- a/__tests__/migration.sample.test.js
+++ b/__tests__/migration.sample.test.js
@@ -5,6 +5,18 @@ const { spawn } = require('child_process');
 
 jest.setTimeout(30000);
 
+async function waitFor(url, timeout = 30000) {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch (_) {}
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error('Server did not start in time');
+}
+
 describe('mysql to postgres migration sample', () => {
   let tmpDir;
   let server;
@@ -18,7 +30,7 @@ describe('mysql to postgres migration sample', () => {
       env: { ...process.env, UNIORM_SAMPLE_DIR: tmpDir },
       stdio: 'ignore'
     });
-    await new Promise((res) => setTimeout(res, 500));
+    await waitFor('http://localhost:6499/health');
   });
 
   afterAll(async () => {

--- a/__tests__/mongo_adapter.test.js
+++ b/__tests__/mongo_adapter.test.js
@@ -1,7 +1,7 @@
 const { MongoAdapter } = require('../src/adapters/MongoAdapter');
 
 // Allow extra time for the MongoDB binary download on fresh environments
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('MongoAdapter', () => {
   let adapter;

--- a/__tests__/mongo_adapter.test.js
+++ b/__tests__/mongo_adapter.test.js
@@ -1,5 +1,8 @@
 const { MongoAdapter } = require('../src/adapters/MongoAdapter');
 
+// Allow extra time for the MongoDB binary download on fresh environments
+jest.setTimeout(30000);
+
 describe('MongoAdapter', () => {
   let adapter;
 


### PR DESCRIPTION
## Summary
- run CI tests across multiple OSes using Node 18

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689f0f12f2188323998b25750fed6904